### PR TITLE
Add extension manifest json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Light tab suspender for Chrome",
+  "description": "Great suspender alternative",
+  "version": "1.0",
+  "manifest_version": 2,
+  "permissions": [
+    "tabs"
+  ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  "commands": {
+    "suspend_tab": {
+      "suggested_key": {
+        "default": "Alt+S"
+      },
+      "description": "Suspend / Unsuspend Tab"
+    }
+  }
+}


### PR DESCRIPTION
## Proposal
Only permissions required so far is with tabs: required to get the tab
url, which is appended to the suspended tab url.

The suspend_tab command is a toggle for suspending and unsuspending the
active tab. The default shortcut should be universal: Alt + S.


### Related Issues
None


### Dependencies
~~#4~~
