### PR TITLE
Add background js to suspend/unsuspend active tab

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,32 @@
+const suspendUrl = `chrome-extension://${chrome.runtime.id}/tab.html`;
+
+function suspend(tab) {
+  const url = `${suspendUrl}#url=${tab.url}`;
+  chrome.tabs.update(tab.id, { url }); 
+}
+
+function unsuspend(tab) {
+  chrome.tabs.update(tab.id, { url: getUrl(tab.url) });
+}
+
+function getUrl(url) {
+  const uri = new URL(url).hash;
+  const params = new URLSearchParams(uri.substring(1));
+  return params.get('url');
+}
+
+chrome.commands.onCommand.addListener((command) => {
+  if (command === "suspend_tab") {
+    chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+      if (tab === null) {
+        return;
+      }
+
+      if (tab.url.includes(suspendUrl)) {
+        unsuspend(tab);
+      } else {
+        suspend(tab);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Proposal
Add the extension's background.js that suspends or unsuspends
the active tab, when the extension's command `suspend_tab`
(default shortcut Alt + S) is used.

The suspended tab uses the extension's tab.html file, with the
tab's URL appended so it can be restored.

Follow ups:
- Show tab title & favicon icon: #6
- Use chrome discard API: #7


### Related Issues
None


### Dependencies
None
